### PR TITLE
Fixed to not submit with 'enter' keystroke if passwords do not match

### DIFF
--- a/src/components/MultiStepForm/MultiStepForm.tsx
+++ b/src/components/MultiStepForm/MultiStepForm.tsx
@@ -63,7 +63,8 @@ const MultiStepForm: FC<Props> = ({ registerSubmit }) => {
 
   const onSubmit = (e: FormEvent) => {
     e.preventDefault();
-    if (!isLast) return nextStep();
+    if ((isFirst) && !(formData.password === formData.repeatPassword)) return;
+    else if (!isLast) return nextStep();
     registerSubmit(formData);
   };
 
@@ -84,11 +85,11 @@ const MultiStepForm: FC<Props> = ({ registerSubmit }) => {
               buttonType="submit"
               active={
                 formData.password.length >= 8 &&
-                isValidEmail(formData.email)
+                  isValidEmail(formData.email)
                   ? true
                   : false
               }
-              onButtonClick={() => {}}
+              onButtonClick={() => { }}
             />
 
             {!isFirst && (


### PR DESCRIPTION
Found one can go to step 2 in register on phone and with enter keystroke even if passwords do not match.
Perhaps we want some alert boxes as well? Or the red input fields will suffice