### PR TITLE
ticket info mambo requested is now in the tutorial

### DIFF
--- a/src/views/TutorialView/TutorialView.tsx
+++ b/src/views/TutorialView/TutorialView.tsx
@@ -19,7 +19,7 @@ const TutorialView: FC<Props> = () => {
           possible to increase your chance to win! 
           Standard tickets are worth 3 points and Super Tickets are worth 10.
           To get tickets, talk to the different booths at the armada fair and be rewarded tickets when
-          completing their tasks. But watch out! There are only 15 super tickets per booth!
+          completing their tasks. But watch out! There are only 30 Super Tickets a day per booth!
         </p>
         <img src={ticketCounter} alt="Ticket counter" />
       </div>

--- a/src/views/TutorialView/TutorialView.tsx
+++ b/src/views/TutorialView/TutorialView.tsx
@@ -15,10 +15,11 @@ const TutorialView: FC<Props> = () => {
       <div className="text-img tutorialbox">
         <p>
           <strong>Goal:</strong> Win the prises at the raffle a week after
-          armada! How to win: Collect as many super tickets for the raffle as
-          possible to increase your chance to win! To get tickets, talk to the
-          different booths at the armada fair and be rewarded tickets when
-          completing their tasks.
+          armada! How to win: Collect as many tickets for the raffle as
+          possible to increase your chance to win! 
+          Standard tickets are worth 3 points and Super Tickets as worth 10.
+          To get tickets, talk to the different booths at the armada fair and be rewarded tickets when
+          completing their tasks. But watch out! There are only 15 super tickets per booth!
         </p>
         <img src={ticketCounter} alt="Ticket counter" />
       </div>

--- a/src/views/TutorialView/TutorialView.tsx
+++ b/src/views/TutorialView/TutorialView.tsx
@@ -17,7 +17,7 @@ const TutorialView: FC<Props> = () => {
           <strong>Goal:</strong> Win the prises at the raffle a week after
           armada! How to win: Collect as many tickets for the raffle as
           possible to increase your chance to win! 
-          Standard tickets are worth 3 points and Super Tickets as worth 10.
+          Standard tickets are worth 3 points and Super Tickets are worth 10.
           To get tickets, talk to the different booths at the armada fair and be rewarded tickets when
           completing their tasks. But watch out! There are only 15 super tickets per booth!
         </p>


### PR DESCRIPTION
I can't load the page, but I think that is unrelated to this change.